### PR TITLE
Include ethereum folder in parity mirror URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 parity_version: 2.0.8
 parity_platform: x86_64-unknown-linux-gnu
-parity_mirror: https://releases.parity.io
+parity_mirror: https://releases.parity.io/ethereum
 parity_checksums:
   '2.0.8':
     x86_64-unknown-linux-gnu: sha256:f9f109f81693e790ca2c9771ddaea9ab3286d971b6f7242b627552c18ecd564a


### PR DESCRIPTION
The [parity binary downloads](https://vanity-service.parity.io/parity-binaries?format=markdown&version=v2.5.9) appear to be located at `https://releases.parity.io/ethereum` now rather than just `https://releases.parity.io`. This appears to affect older (2.0.8) versions as well.